### PR TITLE
Add script to download and prepare image files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,32 @@
-# shell_script_for_image
+# Download and Prepare Image Script
+
+This script automates the process of downloading a tar.gz image file, extracting it, and preparing the contents.
+
+## Prerequisites
+
+- `axel`: This script uses `axel` for accelerated downloads. If you don't have it, install it using your package manager (e.g., `sudo apt install axel` on Debian/Ubuntu).
+
+## Usage
+
+1.  Make sure the script `download_and_prepare_image.sh` is executable:
+    ```bash
+    chmod +x download_and_prepare_image.sh
+    ```
+
+2.  Run the script by providing the download link as a command-line argument:
+    ```bash
+    ./download_and_prepare_image.sh <your_download_link>
+    ```
+    Replace `<your_download_link>` with the actual URL of the tar.gz file.
+
+## Script Steps
+
+1.  **Downloads the File**: Uses `axel -n 100 <link> -o image.tar.gz` to download the specified tar.gz file.
+2.  **Creates `updateImage` Directory**: A directory named `updateImage` is created in the same location as the script.
+3.  **Extracts Archive**: The downloaded `image.tar.gz` is extracted into the `updateImage` directory.
+4.  **Deletes `image.tar.gz`**: The downloaded archive file is removed after successful extraction.
+5.  **File Operations in `updateImage`**:
+    *   Deletes `dtb.bin`.
+    *   Renames `do_not_use.img` to `data.img`.
+    *   Renames `dtb_RW.bin` to `dtb.bin`.
+6.  **Error Handling**: The script includes error checks at each major step and will exit if an error occurs.

--- a/download_and_prepare_image.sh
+++ b/download_and_prepare_image.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+
+# Check if a download link is provided
+if [ -z "$1" ]; then
+  echo "Usage: $0 <download_link>"
+  exit 1
+fi
+
+LINK=$1
+
+# Download the file using axel
+echo "Downloading image from $LINK..."
+axel -n 100 "$LINK" -o image.tar.gz
+
+# Check if axel command was successful
+if [ $? -ne 0 ]; then
+  echo "Error: Download failed."
+  exit 1
+fi
+
+echo "Download successful: image.tar.gz"
+
+# Create updateImage directory
+echo "Creating directory updateImage..."
+mkdir updateImage
+
+# Check if mkdir command was successful
+if [ $? -ne 0 ]; then
+  echo "Error: Failed to create directory updateImage. It may already exist."
+  exit 1
+fi
+
+# Extract the image
+echo "Extracting image.tar.gz to updateImage..."
+tar -xzf image.tar.gz -C updateImage
+
+# Check if tar command was successful
+if [ $? -ne 0 ]; then
+  echo "Error: Extraction failed."
+  exit 1
+fi
+
+echo "Extraction successful."
+
+# Change directory to updateImage
+echo "Changing directory to updateImage..."
+cd updateImage
+
+# Check if cd command was successful
+if [ $? -ne 0 ]; then
+  echo "Error: Failed to change directory to updateImage."
+  exit 1
+fi
+
+# Delete dtb.bin
+echo "Deleting dtb.bin..."
+rm dtb.bin
+if [ $? -ne 0 ]; then
+  echo "Error: Failed to delete dtb.bin."
+  # It might not be critical, so we can choose to continue or exit
+  # For now, let's exit to be safe
+  cd .. # Attempt to go back before exiting
+  exit 1
+fi
+
+# Rename do_not_use.img to data.img
+echo "Renaming do_not_use.img to data.img..."
+mv do_not_use.img data.img
+if [ $? -ne 0 ]; then
+  echo "Error: Failed to rename do_not_use.img to data.img."
+  cd .. # Attempt to go back before exiting
+  exit 1
+fi
+
+# Rename dtb_RW.bin to dtb.bin
+echo "Renaming dtb_RW.bin to dtb.bin..."
+mv dtb_RW.bin dtb.bin
+if [ $? -ne 0 ]; then
+  echo "Error: Failed to rename dtb_RW.bin to dtb.bin."
+  cd .. # Attempt to go back before exiting
+  exit 1
+fi
+
+echo "File operations successful."
+
+# Change back to the original directory
+echo "Changing back to the original directory..."
+cd ..
+if [ $? -ne 0 ]; then
+  echo "Error: Failed to change back to the original directory."
+  exit 1
+fi
+
+# Remove the downloaded archive
+echo "Removing image.tar.gz..."
+rm image.tar.gz
+
+# Check if rm command was successful
+if [ $? -ne 0 ]; then
+  echo "Error: Failed to remove image.tar.gz."
+  exit 1
+fi
+
+echo "Cleanup successful."
+exit 0


### PR DESCRIPTION
This commit introduces a new shell script `download_and_prepare_image.sh` that automates the process of managing image files.

The script performs the following actions:
1.  Downloads a `.tar.gz` file from a user-provided link using `axel -n 100`. It saves the downloaded file as `image.tar.gz`.
2.  Creates a directory named `updateImage`.
3.  Extracts the contents of `image.tar.gz` into the `updateImage` directory.
4.  Deletes the downloaded `image.tar.gz` file after successful extraction.
5.  Performs file operations within the `updateImage` directory:
    - Deletes `dtb.bin`.
    - Renames `do_not_use.img` to `data.img`.
    - Renames `dtb_RW.bin` to `dtb.bin`.
6.  The script includes error handling for each major step (download, directory creation, extraction, file operations) and will exit if an error occurs.

A `README.md` file has also been added to provide instructions on how to use the script, including prerequisites like installing `axel`.

Testing confirmed that the script's core logic for file manipulation and error handling for extraction works correctly. You should be aware that `axel` may not be able to download files from all types of URLs directly (e.g., those requiring user interaction or complex redirects like some Google Drive links). A direct link to the `tar.gz` file is recommended for reliable downloads.